### PR TITLE
allow multiple connections from same ip address

### DIFF
--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -222,7 +222,7 @@ type torrent struct {
 	seedDurationUpdatedAt time.Time
 	seedDurationTicker    *time.Ticker
 
-	// Holds connected peer IPs so we don't dial/accept multiple connections to/from same IP.
+	// Holds connected peer IP:port info
 	connectedPeerIPs map[string]struct{}
 
 	// Peers that are sending corrupt data are banned.

--- a/torrent/torrent_close.go
+++ b/torrent/torrent_close.go
@@ -40,7 +40,7 @@ func (t *torrent) closePeer(pe *peer.Peer) {
 	delete(t.incomingPeers, pe)
 	delete(t.outgoingPeers, pe)
 	delete(t.peerIDs, pe.ID)
-	delete(t.connectedPeerIPs, pe.Conn.IP())
+	delete(t.connectedPeerIPs, pe.String())
 	if t.piecePicker != nil {
 		t.piecePicker.HandleDisconnect(pe)
 	}

--- a/torrent/torrent_connection.go
+++ b/torrent/torrent_connection.go
@@ -13,7 +13,7 @@ func (t *torrent) handleNewConnection(conn net.Conn) {
 		return
 	}
 	ip := conn.RemoteAddr().(*net.TCPAddr).IP
-	ipstr := ip.String()
+	ipstr := conn.RemoteAddr().String()
 	if t.session.config.BlocklistEnabledForIncomingConnections && t.session.blocklist != nil && t.session.blocklist.Blocked(ip) {
 		t.log.Debugln("peer is blocked:", conn.RemoteAddr().String())
 		conn.Close()

--- a/torrent/torrent_handshake.go
+++ b/torrent/torrent_handshake.go
@@ -1,8 +1,6 @@
 package torrent
 
 import (
-	"net"
-
 	"github.com/cenkalti/rain/internal/handshaker/incominghandshaker"
 	"github.com/cenkalti/rain/internal/handshaker/outgoinghandshaker"
 	"github.com/cenkalti/rain/internal/peersource"
@@ -22,7 +20,7 @@ func (t *torrent) checkInfoHash(infoHash [20]byte) bool {
 func (t *torrent) handleIncomingHandshakeDone(ih *incominghandshaker.IncomingHandshaker) {
 	delete(t.incomingHandshakers, ih)
 	if ih.Error != nil {
-		delete(t.connectedPeerIPs, ih.Conn.RemoteAddr().(*net.TCPAddr).IP.String())
+		delete(t.connectedPeerIPs, ih.Conn.RemoteAddr().String())
 		return
 	}
 	t.startPeer(ih.Conn, peersource.Incoming, t.incomingPeers, ih.PeerID, ih.Extensions, ih.Cipher)
@@ -31,7 +29,7 @@ func (t *torrent) handleIncomingHandshakeDone(ih *incominghandshaker.IncomingHan
 func (t *torrent) handleOutgoingHandshakeDone(oh *outgoinghandshaker.OutgoingHandshaker) {
 	delete(t.outgoingHandshakers, oh)
 	if oh.Error != nil {
-		delete(t.connectedPeerIPs, oh.Addr.IP.String())
+		delete(t.connectedPeerIPs, oh.Addr.String())
 		t.dialAddresses()
 		return
 	}

--- a/torrent/torrent_peer.go
+++ b/torrent/torrent_peer.go
@@ -100,7 +100,7 @@ func (t *torrent) dialAddresses() {
 			t.setNeedMorePeers(true)
 			return
 		}
-		ip := addr.IP.String()
+		ip := addr.String()
 		if _, ok := t.connectedPeerIPs[ip]; ok {
 			continue
 		}


### PR DESCRIPTION
this PR is to allow multiple connections from same ip address (due to test runner instancess sharing IPs) in rain
use `ip:port` as the key in `connectedPeerIPs` map instead of just IP